### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist
 dist-ssr
 *.local
 
+.env
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
@@ -22,3 +24,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+


### PR DESCRIPTION
Adds .env to gitignore file

.env.example is tracked in version control. The local copy the user makes when setting up their dev environment does not need to be tracked.